### PR TITLE
Add parameters to control visual display of correlation coefficients

### DIFF
--- a/R/corrplot.R
+++ b/R/corrplot.R
@@ -19,6 +19,8 @@ corrplot <- function(corr,
 		cl.pos = NULL, cl.lim = NULL,
 		cl.length = NULL, cl.cex = 0.8, cl.ratio = 0.15, 
 		cl.align.text = "c", cl.offset=0.5,
+		
+		number.cex = 1, number.font = 2,
 
 		addshade = c("negative", "positive", "all"),
 		shade.lwd = 1, shade.col = "white",
@@ -228,9 +230,10 @@ corrplot <- function(corr,
 
 	## number
 	if(method=="number"&plotCI=="n"){
-		text(Pos[,1], Pos[,2], font = 2, col = col.fill,
+		text(Pos[,1], Pos[,2], font = number.font, col = col.fill,
 		labels = round((DAT-int)*ifelse(addCoefasPercent, 100, 1)/zoom, 
-				ifelse(addCoefasPercent, 0, 2)))
+				ifelse(addCoefasPercent, 0, 2)),
+		cex = number.cex)
 	}
 
 	## pie
@@ -458,7 +461,8 @@ corrplot <- function(corr,
 	if(!is.null(addCoef.col)&(!method == "number")){
 		text(Pos[,1], Pos[,2],  col = addCoef.col,
 		labels = round((DAT-int)*ifelse(addCoefasPercent, 100, 1)/zoom, 
-				ifelse(addCoefasPercent, 0, 2)))
+				ifelse(addCoefasPercent, 0, 2)),
+		cex = number.cex, font = number.font)
 	}
 	
 	## add grid, in case of the grid is ate when "diag=FALSE"

--- a/man/corrplot.Rd
+++ b/man/corrplot.Rd
@@ -208,6 +208,16 @@ Character, \code{"l"}, \code{"c"} (default) or \code{"r"}, for number-label in c
 Numeric, for number-label in colorlabel, see \code{\link{text}}.
 }
 
+\item{number.cex}{
+The \code{cex} parameter to send to the call to \code{text} when writing
+the correlation coefficients into the plot.
+}
+
+\item{number.font}{
+the \code{font} parameter to send to the call to \code{text} when
+writing the correlation coefficients into the plot.
+}
+
   \item{addshade}{
 Character for shade style, \code{"negative"}, \code{"positive"} or \code{"all"}, 
 only valid when \code{method} is \code{"shade"}. If \code{"all"}, all


### PR DESCRIPTION
The following parameters were added to the `corrplot` function:

  * `number.cex`: Controls text size of correlation coefficients
  * `number.font`: Controls the font used to print the correlation coefficients