### PR TITLE
Set/reset par() no matter if add = TRUE or FALSE

### DIFF
--- a/R/corrplot.R
+++ b/R/corrplot.R
@@ -428,10 +428,10 @@ corrplot <- function(corr,
     col.border <- outline
   }
 
+  oldpar <- par(mar = mar, bg = "white")
+  on.exit(par(oldpar), add = TRUE)
   ## calculate label-text width approximately
   if (!add) {
-    oldpar <- par(mar = mar, bg = "white")
-    on.exit(par(oldpar), add = TRUE)
     plot.new()
     xlabwidth <- ylabwidth <- 0
 


### PR DESCRIPTION
e.g. corrplot.mixed() calls corrplot(add = FALSE) and corrplot(add = TRUE), and we need to make sure the margin is correct during the second call