### PR TITLE
Fixing colour scale for diagonal elements.

### DIFF
--- a/R/corrplot.R
+++ b/R/corrplot.R
@@ -311,7 +311,7 @@ corrplot <- function(corr,
       # if not a correlation matrix and the diagonal is hidden,
       # we need to compute limits from all cells except the diagonal
       corr_tmp <- corr
-      diag(corr_tmp) <- ifelse(diag, diag(corr_tmp), NA)
+      diag(corr_tmp) <- ifelse(rep(diag, length(diag(corr_tmp))), diag(corr_tmp), NA)
       cl.lim <- c(min(corr_tmp, na.rm = TRUE), max(corr_tmp, na.rm = TRUE))
     }
   }


### PR DESCRIPTION
ifelse function returns vector of length equal to the length of condition. Default is "diag = TRUE", which has length one, hence the diagonal is effectively replaced by its first element when constructing the colour scale via corr_tmp. This PR fixes it so the whole diagonal is preserved.

The following code illustrates the problem - compare the colour scales of these plots, the second one is correct, but the first one is not:

library(corrplot)
M <- matrix(data = c(2, 1, 1, 1, -2, 1, 1, 1, 4), nrow = 3)
corrplot(M, is.corr = F)

M <- matrix(data = c(2, 1, 1, -2, 1, 1, 4, 1, 1), nrow = 3)
corrplot(M, is.corr = F)