### PR TITLE
format correlations with nsmall = number.digits

### DIFF
--- a/R/corrplot.R
+++ b/R/corrplot.R
@@ -879,8 +879,13 @@ corrplot = function(corr,
   ## add numbers
   if (!is.null(addCoef.col) && method != 'number') {
     text(Pos[, 1], Pos[, 2],  col = addCoef.col,
-         labels = round((DAT - int) * ifelse(addCoefasPercent, 100, 1) / zoom,
-                        number.digits),
+         labels = format(
+		   round(
+		     (DAT - int) * ifelse(addCoefasPercent, 100, 1) / zoom, 
+			 number.digits
+		   ), 
+		   nsmall = number.digits
+		 ),
          cex = number.cex, font = number.font)
   }
 


### PR DESCRIPTION
Addresses Issue #275.

The correlation between drat and gear is now listed as 0.70 and not 0.7.

``` r
library(dplyr)
library(corrplot)

M <- mtcars |> select(gear, am, drat) |> cor()

corrplot(
  M, 
  type = "lower", 
  diag = FALSE, 
  addCoef.col = "black", 
  number.digits = 2
)
```

![](https://i.imgur.com/eGfQLnb.png)<!-- -->

<sup>Created on 2024-04-29 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
